### PR TITLE
fix jquery mixed content blocked

### DIFF
--- a/dev/edit_area/template.html
+++ b/dev/edit_area/template.html
@@ -5,7 +5,7 @@
 	<title>EditArea</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7"/>
-    <link id="theme" type="text/css" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/overcast/jquery-ui.css" rel="stylesheet">
+    <link id="theme" type="text/css" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/overcast/jquery-ui.css" rel="stylesheet">
     <link type="text/css" href="../css/hq-webui.css" rel="stylesheet">
 
 

--- a/ui/backup.html
+++ b/ui/backup.html
@@ -4,7 +4,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta charset="ISO-8859-1">
     <title>HQ WebUI</title>
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     <script type="text/javascript" src="js/lostorage.min.js"></script>
     <style type="text/css">
         body { font-size: 0.8em; font-family: sans-serif; background-color: #e9e9e9; color: #222; }

--- a/ui/cache.html
+++ b/ui/cache.html
@@ -4,7 +4,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta charset="ISO-8859-1">
     <title>HQ WebUI</title>
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     <script type="text/javascript" src="js/lostorage.min.js"></script>
     <style type="text/css">
         body { font-size: 0.8em; font-family: sans-serif; background-color: #e9e9e9; color: #222; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="ISO-8859-1">
     <title>HQ WebUI</title>
-    <link id="theme" type="text/css" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/redmond/jquery-ui.css" rel="stylesheet">
+    <link id="theme" type="text/css" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/redmond/jquery-ui.css" rel="stylesheet">
     <link type="text/css" href="css/ui.jqgrid.css" rel="stylesheet">
     <link type="text/css" href="css/jquery.multiselect.css" rel="stylesheet">
     <!--<link rel="stylesheet" href="css/jquery.jsonview.css" type="text/css" media="screen" title="no title" charset="utf-8">-->

--- a/ui/index.min.html
+++ b/ui/index.min.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="ISO-8859-1">
     <title>HQ WebUI</title>
-    <link id="theme" type="text/css" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/redmond/jquery-ui.css" rel="stylesheet">
+    <link id="theme" type="text/css" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/redmond/jquery-ui.css" rel="stylesheet">
     <link type="text/css" href="css/ui.jqgrid.css" rel="stylesheet">
     <link type="text/css" href="css/jquery.multiselect.css" rel="stylesheet">
     <link rel="stylesheet" href="css/jquery.jsonview.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <script language="javascript" type="text/javascript" src="edit_area/edit_area_full.js"></script>
     <link type="text/css" href="css/hq-webui.css" rel="stylesheet">
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     <script type="text/javascript" src="js/lostorage.min.js"></script>
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
     <script type="text/javascript" src="js/i18n/grid.locale-de.js"></script>
     <script type="text/javascript" src="js/jquery.jqGrid.min.js"></script>
     <script type="text/javascript" src="js/jquery.multiselect.min.js"></script>

--- a/ui/js/config.js
+++ b/ui/js/config.js
@@ -58,7 +58,7 @@ var hqConf = {
 
     // jQuery UI Theme
     themeDefault:           "redmond",
-    themeUrl:               "http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/",
+    themeUrl:               "https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/themes/",
     themeSuffix:            "/jquery-ui.css",
 
     // Geräte-Bildchen anzeigen


### PR DESCRIPTION
fixes issue #10 Mixed Content blocks jquery breaking the site if hq-webui is loaded via HTTPS.
All occurences in the code were simply replaced by https urls.